### PR TITLE
Add dependency to graphviz

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -43,6 +43,7 @@
   <build_depend>rospy</build_depend>
   <run_depend>rospy</run_depend>
 
+  <run_depend>python-graphviz</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
This package uses Graphviz but did not state it's dependency on GraphViz. 

Alerted via https://github.com/tue-robotics/tue_robocup/issues/161 