### PR TITLE
Report sentence error position for outside-grammar sentences

### DIFF
--- a/src/grammar_parser/cfgparser.py
+++ b/src/grammar_parser/cfgparser.py
@@ -405,7 +405,7 @@ class CFGParser:
         """
         Add a new function to the parser. Must be done before loading the grammar.
 
-        Todo: Ensure the function expansion result does not refer to missing sub-rules or functions.
+        TODO #11: Ensure the function expansion result does not refer to missing sub-rules or functions.
         """
         self.functions[name] = func
 

--- a/src/grammar_parser/cfgparser.py
+++ b/src/grammar_parser/cfgparser.py
@@ -473,6 +473,9 @@ class CFGParser:
                 return None
             return word_index
 
+        if  len(T.option.conjuncts) == idx:
+            return self._parse(T.next(idx), words, word_index)
+
         # At least one grammar symbol exists.
         conj = T.option.conjuncts[idx]
 

--- a/src/grammar_parser/cfgparser.py
+++ b/src/grammar_parser/cfgparser.py
@@ -328,7 +328,8 @@ class CFGParser:
     sub-rules and missing functions while loading. The CFGParser.verify function
     goes a step further by expanding all alternatives.
 
-    To parse a sentence, use CFGParser.parse()
+    To parse a sentence, use parse_raw() at a CFGParser instance to get maximum information, or
+    use parse() at a CFGParser instance to avoid getting exceptions.
     """
     def __init__(self):
         self.rules = {}
@@ -425,6 +426,58 @@ class CFGParser:
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     def parse(self, target, words, debug=False):
+        """
+        Parse the given sentence against the grammar loaded in the class. This
+        method hides all errors (and returns False in that case). Use the
+        self.parse_raw function if the difference between a successful and
+        failed parse is relevant.
+
+        :param target: Target rule in the grammar to start parsing the sentence.
+        :type target: str.
+
+        :param words: Sentence to parse, either as a single string or a list of words.
+        :type words: str, or a list of str.
+
+        :param debug: If True, output the matched sequence in the tree.
+        :type debug: Boolean, by default False.
+
+        :return: The captured data value collected during parsing if parsing
+                 succeeds, else False.
+        """
+        try:
+            return self.parse_raw(target, words, debug)
+
+        except GrammarError as ex:
+            print "grammar_parser, Grammar error: {}".format(ex)
+            return False
+
+        except ParseError as ex:
+            print "grammar_parser, Parse error: {}".format(ex)
+            return False
+
+        return False
+
+
+    def parse_raw(self, target, words, debug=False):
+        """
+        Parse the given sentence against the grammar loaded in the class. This
+        method throws exceptions on failures, the self.parse function returns
+        False in such a case.
+
+        :param target: Target rule in the grammar to start parsing the sentence.
+        :type target: str.
+
+        :param words: Sentence to parse, either as a single string or a list of words.
+        :type words: str, or a list of str.
+
+        :param debug: If True, output the matched sequence in the tree.
+        :type debug: Boolean, by default False.
+
+        :return: The captured data value collected during parsing if parsing
+                 succeeds, a GrammarError exception if the grammar is found to
+                 be incorrect, or a ParseError exception if the sentence fails
+                 to match the grammar.
+        """
         if isinstance(words, basestring):
             words = words.split(" ")
 

--- a/src/grammar_parser/cfgparser.py
+++ b/src/grammar_parser/cfgparser.py
@@ -376,6 +376,13 @@ class CFGParser:
         return False
 
     def _parse(self, TIdx, words):
+        """
+        Try to match the provided words on the given grammar rule option.
+
+        :param TIdx: Tuple of grammar Rule, and rule alternative index.
+        :param words: Words to match on the alternative.
+        :return: Whether the words could be matched on the alternative.
+        """
         (T, idx) = TIdx
 
         if not T:

--- a/src/grammar_parser/cfgparser.py
+++ b/src/grammar_parser/cfgparser.py
@@ -388,23 +388,26 @@ class CFGParser:
         if not T:
             return words == []
 
-        if not words:
-            return False
-
         conj = T.option.conjuncts[idx]
 
         if conj.is_variable:
+            # Conjunct is a sub-rule.
             if not conj.name in self.rules:
                 return False
             options = self.rules[conj.name].options
 
         elif conj.name[0] == "$":
+            # Conjunct is a function that must be expanded to a sub-rule.
             func_name = conj.name[1:]
             if not func_name in self.functions:
                 return False
             options = self.functions[func_name](words)
 
         else:
+            # Conjunct is an actual word.
+            if not words:
+                return False
+
             if conj.name == words[0]:
                 return self._parse(T.next(idx), words[1:])
             else:

--- a/src/grammar_parser/test/test_cfgparser.py
+++ b/src/grammar_parser/test/test_cfgparser.py
@@ -174,22 +174,28 @@ class TestSingleRule(unittest.TestCase):
         self.p = CFGParser.fromstring(grammar)
 
     def test_single1(self):
-        self.assertEquals(self.p.parse(self.target_rule, ''), False)
+        with self.assertRaises(ParseError):
+            self.p.parse(self.target_rule, '') # Missing first token 'a'.
 
     def test_single2(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'a'), False)
+        with self.assertRaises(ParseError):
+            self.p.parse(self.target_rule, 'a') # Missing second token 'b'.
 
     def test_single3(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'b'), False)
+        with self.assertRaises(ParseError):
+            self.p.parse(self.target_rule, 'b') # Incorrect first token.
 
     def test_single4(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'q'), False)
+        with self.assertRaises(ParseError):
+            self.p.parse(self.target_rule, 'q') # Incorrect first token.
 
     def test_single5(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'a b'), False)
+        with self.assertRaises(ParseError):
+            self.p.parse(self.target_rule, 'a b') # Missing third token.
 
     def test_single6(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'a b c d'), False)
+        with self.assertRaises(ParseError):
+            self.p.parse(self.target_rule, 'a b c d') # Too many words.
 
     def test_single7(self):
         self.assertEquals(self.p.parse(self.target_rule, 'a b c'), {'key': 'value'})
@@ -226,22 +232,17 @@ class TestEmptySubrules(unittest.TestCase):
         self.p = CFGParser.fromstring(grammar)
 
     def test_empty_subrule1(self):
-        # XXX False negative, should reduce to 'a' with D being the empty option.
-        self.assertEquals(self.p.parse(self.target_rule, 'p'), False)
+        self.assertEquals(self.p.parse(self.target_rule, 'p'), 'a') # D reduces to empty.
 
     def test_empty_subrule2(self):
-        # XXX False negative, should reduce to 'b' with E being the empty option.
-        self.assertEquals(self.p.parse(self.target_rule, 'q'), False)
+        self.assertEquals(self.p.parse(self.target_rule, 'q'), 'b') # E reduces to empty.
 
     def test_empty_subrule3(self):
-        # XXX Crashes the parser.
-        with self.assertRaises(IndexError):
-            self.assertEquals(self.p.parse(self.target_rule, 'p r'), 'a')
+        self.assertEquals(self.p.parse(self.target_rule, 'p r'), 'a')
 
     def test_empty_subrule4(self):
         self.assertEquals(self.p.parse(self.target_rule, 'q r'), 'b')
 
     def test_empty_subrule5(self):
-        # XXX Crashes the parser.
-        with self.assertRaises(IndexError):
-            self.assertEquals(self.p.parse(self.target_rule, 'q x'), False)
+        with self.assertRaises(ParseError):
+            self.p.parse(self.target_rule, 'q x') # Incorrect second token.

--- a/src/grammar_parser/test/test_cfgparser.py
+++ b/src/grammar_parser/test/test_cfgparser.py
@@ -175,30 +175,30 @@ class TestSingleRule(unittest.TestCase):
 
     def test_single1(self):
         with self.assertRaises(ParseError):
-            self.p.parse(self.target_rule, '') # Missing first token 'a'.
+            self.p.parse_raw(self.target_rule, '') # Missing first token 'a'.
 
     def test_single2(self):
         with self.assertRaises(ParseError):
-            self.p.parse(self.target_rule, 'a') # Missing second token 'b'.
+            self.p.parse_raw(self.target_rule, 'a') # Missing second token 'b'.
 
     def test_single3(self):
         with self.assertRaises(ParseError):
-            self.p.parse(self.target_rule, 'b') # Incorrect first token.
+            self.p.parse_raw(self.target_rule, 'b') # Incorrect first token.
 
     def test_single4(self):
         with self.assertRaises(ParseError):
-            self.p.parse(self.target_rule, 'q') # Incorrect first token.
+            self.p.parse_raw(self.target_rule, 'q') # Incorrect first token.
 
     def test_single5(self):
         with self.assertRaises(ParseError):
-            self.p.parse(self.target_rule, 'a b') # Missing third token.
+            self.p.parse_raw(self.target_rule, 'a b') # Missing third token.
 
     def test_single6(self):
         with self.assertRaises(ParseError):
-            self.p.parse(self.target_rule, 'a b c d') # Too many words.
+            self.p.parse_raw(self.target_rule, 'a b c d') # Too many words.
 
     def test_single7(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'a b c'), {'key': 'value'})
+        self.assertEquals(self.p.parse_raw(self.target_rule, 'a b c'), {'key': 'value'})
 
 class TestSubrules(unittest.TestCase):
     def setUp(self):
@@ -212,10 +212,10 @@ class TestSubrules(unittest.TestCase):
         self.p = CFGParser.fromstring(grammar)
 
     def test_sub1(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'p'), 'a')
+        self.assertEquals(self.p.parse_raw(self.target_rule, 'p'), 'a')
 
     def test_sub2(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'q'), 'b')
+        self.assertEquals(self.p.parse_raw(self.target_rule, 'q'), 'b')
 
 
 class TestEmptySubrules(unittest.TestCase):
@@ -232,17 +232,17 @@ class TestEmptySubrules(unittest.TestCase):
         self.p = CFGParser.fromstring(grammar)
 
     def test_empty_subrule1(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'p'), 'a') # D reduces to empty.
+        self.assertEquals(self.p.parse_raw(self.target_rule, 'p'), 'a') # D reduces to empty.
 
     def test_empty_subrule2(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'q'), 'b') # E reduces to empty.
+        self.assertEquals(self.p.parse_raw(self.target_rule, 'q'), 'b') # E reduces to empty.
 
     def test_empty_subrule3(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'p r'), 'a')
+        self.assertEquals(self.p.parse_raw(self.target_rule, 'p r'), 'a')
 
     def test_empty_subrule4(self):
-        self.assertEquals(self.p.parse(self.target_rule, 'q r'), 'b')
+        self.assertEquals(self.p.parse_raw(self.target_rule, 'q r'), 'b')
 
     def test_empty_subrule5(self):
         with self.assertRaises(ParseError):
-            self.p.parse(self.target_rule, 'q x') # Incorrect second token.
+            self.p.parse_raw(self.target_rule, 'q x') # Incorrect second token.


### PR DESCRIPTION
To find gaps in the set recognized commands, one needs to compare the grammar against externally provided commands. This patch speeds up that process by raising an exception if grammar parsing fails, by returning an indication of the longest matched part of a command.

While this patch is always active, note that under normal circumstances the sentence provided by the speech recognition always fits in the grammar, since the recognition uses the grammar as limit to recognize the speech. As a result, in normal operation the exception will never trigger (or rather, should never trigger).